### PR TITLE
Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,23 @@ Style, modularize, and implement context
 
 ### Tasks
 
-- [ ] Style with [Blueprint UI Kit](https://blueprintjs.com/docs/#blueprint)
+- [X] Style with [Blueprint UI Kit](https://blueprintjs.com/docs/#blueprint)
 - [x] Modularize application
 - [x] Implement context API
   - Manages number of items per page {int}
   - Hide or show completed items {bool}
+
+## Phase 2
+
+Paginate, hide, customize, save
+
+### Tasks
+
+- [x] Implement pagination with context api
+- [ ] Hide or show completed items based on context
+- [ ] Allow the user to set preferences for hide/show and page size
+- [ ] Save preference to local storage
+- [ ] Retrieve preferences from local storage
 
 ## Further reading
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ Paginate, hide, customize, save
 ### Tasks
 
 - [x] Implement pagination with context api
-- [ ] Hide or show completed items based on context
-- [ ] Allow the user to set preferences for hide/show and page size
-- [ ] Save preference to local storage
-- [ ] Retrieve preferences from local storage
+- [x] Hide or show completed items based on context
+- [x] Allow the user to set preferences for hide/show and page size
+- [x] Save preference to local storage
+- [x] Retrieve preferences from local storage
 
+## Phase 3
+
+### Tasks
 ## Further reading
 
 [JSDoc – documentation](https://jsdoc.app/)

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,3 +1,41 @@
 @import "~normalize.css";
 @import "~@blueprintjs/core/lib/css/blueprint.css";
 @import "~@blueprintjs/icons/lib/css/blueprint-icons.css";
+@import "~@blueprintjs/core/lib/scss/variables";
+
+html {
+  background-color: $light-gray1;
+}
+
+.bp3-navbar {
+  background: $white;
+}
+
+#content-wrapper {
+  width: 90vw;
+  padding: 2%;
+  height: 90vh;
+  display: flex;
+  justify-content: space-between;
+}
+
+#form {
+  width: 30%;
+  height: 50%;
+  margin: 2%;
+  margin-left: 2%;
+
+  input {
+    margin-top: 2%;
+  }
+
+  button {
+    margin-left: 2%;
+  }
+}
+
+.card-wrapper {
+  width: 80vw;
+  padding: 20px;
+  margin: 2%;
+}

--- a/src/components/todo/form.js
+++ b/src/components/todo/form.js
@@ -15,7 +15,9 @@ import {
 import { SettingsContext } from '../../context/settings';
 
 function Form({ handleChange, handleSubmit }) {
-  const { toggleShow, changeItemsPerPage } = useContext(SettingsContext);
+  const {
+    showComplete, toggleShow, pageNumber, changeItemsPerPage,
+  } = useContext(SettingsContext);
   return (
     <Card id="form" interactive elevation={Elevation.FOUR}>
       <form onSubmit={handleSubmit}>
@@ -43,11 +45,11 @@ function Form({ handleChange, handleSubmit }) {
 
         <label>
           <span>Show completed</span>
-          <Switch onClick={toggleShow} />
+          <Switch checked={showComplete} onChange={toggleShow} />
         </label>
         <label>
           <span>Items per page</span>
-          <input type="number" min="1" max="10" onChange={changeItemsPerPage} />
+          <input type="number" min="1" max="10" value={pageNumber} onChange={changeItemsPerPage} />
         </label>
       </form>
     </Card>

--- a/src/components/todo/form.js
+++ b/src/components/todo/form.js
@@ -5,16 +5,16 @@ import React from 'react';
 import propTypes from 'prop-types';
 import {
   Card,
-  FormGroup,
   H2,
   InputGroup,
   Button,
+  Elevation,
 } from '@blueprintjs/core';
 
 function Form({ handleChange, handleSubmit }) {
   return (
-    <Card>
-      <FormGroup onSubmit={handleSubmit}>
+    <Card id="form" interactive elevation={Elevation.FOUR}>
+      <form onSubmit={handleSubmit}>
 
         <H2>Add To Do Item</H2>
 
@@ -36,7 +36,7 @@ function Form({ handleChange, handleSubmit }) {
         <label>
           <Button type="submit">Add Item</Button>
         </label>
-      </FormGroup>
+      </form>
     </Card>
   );
 }

--- a/src/components/todo/form.js
+++ b/src/components/todo/form.js
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable react/jsx-filename-extension */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import propTypes from 'prop-types';
 import {
   Card,
@@ -9,9 +9,13 @@ import {
   InputGroup,
   Button,
   Elevation,
+  Switch,
 } from '@blueprintjs/core';
 
+import { SettingsContext } from '../../context/settings';
+
 function Form({ handleChange, handleSubmit }) {
+  const { toggleShow, changeItemsPerPage } = useContext(SettingsContext);
   return (
     <Card id="form" interactive elevation={Elevation.FOUR}>
       <form onSubmit={handleSubmit}>
@@ -35,6 +39,15 @@ function Form({ handleChange, handleSubmit }) {
 
         <label>
           <Button type="submit">Add Item</Button>
+        </label>
+
+        <label>
+          <span>Show completed</span>
+          <Switch onClick={toggleShow} />
+        </label>
+        <label>
+          <span>Items per page</span>
+          <input type="number" min="1" max="10" onChange={changeItemsPerPage} />
         </label>
       </form>
     </Card>

--- a/src/components/todo/list.js
+++ b/src/components/todo/list.js
@@ -3,12 +3,13 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
 import propTypes from 'prop-types';
+import { Card, Elevation, Button } from '@blueprintjs/core';
 
 function List({ list, toggleComplete }) {
   return (
-    <>
+    <section className="card-group">
       {list.map((item) => (
-        <div key={item.id}>
+        <Card interactive elevation={Elevation.FOUR} key={item.id}>
           <p>{item.text}</p>
           <p>
             <small>
@@ -22,17 +23,17 @@ function List({ list, toggleComplete }) {
               {item.difficulty}
             </small>
           </p>
-          <div
+          <Button
             role="button"
             onClick={() => toggleComplete(item.id)}
+            intent={item.complete ? 'Success' : 'Danger'}
           >
-            Complete:
-            {item.complete.toString()}
-          </div>
+            {item.complete ? ' complete' : ' incomplete'}
+          </Button>
           <hr />
-        </div>
+        </Card>
       ))}
-    </>
+    </section>
   );
 }
 List.propTypes = {

--- a/src/components/todo/todo.js
+++ b/src/components/todo/todo.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-use-before-define */
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable jsx-a11y/interactive-supports-focus */
 /* eslint-disable jsx-a11y/click-events-have-key-events */
@@ -18,7 +19,6 @@ const ToDo = () => {
   const [incomplete, setIncomplete] = useState([]);
   const [pages, setPages] = useState([]);
   const [activePage, setActivePage] = useState([]);
-  // eslint-disable-next-line no-use-before-define
   const { handleChange, handleSubmit } = useForm(addItem);
 
   const { pageNumber, showComplete } = useContext(SettingsContext);
@@ -29,11 +29,10 @@ const ToDo = () => {
     setList([...list, item]);
   }
 
-  // eslint-disable-next-line no-unused-vars
-  function deleteItem(id) {
-    const items = list.filter((item) => item.id !== id);
-    setList(items);
-  }
+  // function deleteItem(id) {
+  //   const items = list.filter((item) => item.id !== id);
+  //   setList(items);
+  // }
 
   function toggleComplete(id) {
     const items = list.map((item) => {

--- a/src/components/todo/todo.js
+++ b/src/components/todo/todo.js
@@ -6,9 +6,7 @@
 
 import React, { useEffect, useState, useContext } from 'react';
 import { v4 as uuid } from 'uuid';
-import { Navbar, Button } from '@blueprintjs/core';
-
-import { ButtonGroup } from 'react-bootstrap';
+import { Navbar, Button, ButtonGroup } from '@blueprintjs/core';
 import Form from './form';
 import List from './list';
 import { SettingsContext } from '../../context/settings';
@@ -23,7 +21,7 @@ const ToDo = () => {
   // eslint-disable-next-line no-use-before-define
   const { handleChange, handleSubmit } = useForm(addItem);
 
-  const { pageNumber } = useContext(SettingsContext);
+  const { pageNumber, showComplete } = useContext(SettingsContext);
 
   function addItem(item) {
     item.id = uuid();
@@ -70,6 +68,13 @@ const ToDo = () => {
       setActivePage([...segments[0]]);
     }
   }, [list]);
+
+  useEffect(() => {
+    if (!showComplete) {
+      const pendingItems = list.filter((item) => item.complete === false);
+      setList([...pendingItems]);
+    }
+  }, [showComplete]);
 
   return (
     <>

--- a/src/components/todo/todo.js
+++ b/src/components/todo/todo.js
@@ -4,20 +4,26 @@
 /* eslint-disable react/jsx-filename-extension */
 /* eslint-disable no-param-reassign */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { v4 as uuid } from 'uuid';
-import { Navbar } from '@blueprintjs/core';
+import { Navbar, Button } from '@blueprintjs/core';
 
+import { ButtonGroup } from 'react-bootstrap';
 import Form from './form';
 import List from './list';
+import { SettingsContext } from '../../context/settings';
 
 import useForm from '../../hooks/form';
 
 const ToDo = () => {
   const [list, setList] = useState([]);
   const [incomplete, setIncomplete] = useState([]);
+  const [pages, setPages] = useState([]);
+  const [activePage, setActivePage] = useState([]);
   // eslint-disable-next-line no-use-before-define
   const { handleChange, handleSubmit } = useForm(addItem);
+
+  const { pageNumber } = useContext(SettingsContext);
 
   function addItem(item) {
     item.id = uuid();
@@ -48,18 +54,54 @@ const ToDo = () => {
     document.title = `To Do List: ${incomplete}`;
   }, [list]);
 
+  useEffect(() => {
+    let beginning = 0;
+    let end = pageNumber;
+    const segments = [];
+    if (list.length >= pageNumber) {
+      while (list.length > beginning) {
+        const page = list.slice(beginning, end);
+        segments.push(page);
+
+        beginning += pageNumber;
+        end += pageNumber;
+      }
+      setPages([...segments]);
+      setActivePage([...segments[0]]);
+    }
+  }, [list]);
+
   return (
     <>
       <Navbar>
-        <div className="bp3-navbar-heading">
-          To Do List:
-          {incomplete}
-          {' '}
-          items pending
-        </div>
+        <Navbar.Group>
+          <Navbar.Heading> To Do </Navbar.Heading>
+          <Navbar.Divider />
+          <Button className="bp3-minimal" icon="home" text="Home" />
+          <Button className="bp3-minimal" icon="document" text="Files" />
+        </Navbar.Group>
       </Navbar>
-      <Form handleChange={handleChange} handleSubmit={handleSubmit} />
-      <List list={list} toggleComplete={toggleComplete} />
+      <div id="content-wrapper">
+        <Form handleChange={handleChange} handleSubmit={handleSubmit} />
+
+        <List
+          list={list.length >= pageNumber ? activePage : list}
+          toggleComplete={toggleComplete}
+        />
+      </div>
+      { pages.length
+        && (
+          <ButtonGroup>
+            { pages.map((page, idx) => (
+              <Button
+                key={pages.indexOf(page)}
+                onClick={() => setActivePage(pages[idx])}
+              >
+                {pages.indexOf(page) + 1}
+              </Button>
+            ))}
+          </ButtonGroup>
+        )}
     </>
   );
 };

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -11,8 +11,28 @@ function SettingsProvider({ children }) {
   const [pageNumber, setPageNumber] = useState(3);
   // * add search field later
 
+  function toggleShow() {
+    if (showComplete) {
+      setShowComplete(false);
+    } else {
+      setShowComplete(true);
+    }
+  }
+
+  function changeItemsPerPage(e) {
+    const itemsPerPage = Number(e.target.value);
+    console.log(e.target.value);
+    setPageNumber(itemsPerPage);
+  }
+
   return (
-    <SettingsContext.Provider value={{ showComplete, pageNumber }}>
+    <SettingsContext.Provider value={{
+      showComplete,
+      pageNumber,
+      toggleShow,
+      changeItemsPerPage,
+    }}
+    >
       {children}
     </SettingsContext.Provider>
   );

--- a/src/context/settings.js
+++ b/src/context/settings.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable react/jsx-filename-extension */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import propTypes from 'prop-types';
 
 // ? why two exports again?
@@ -12,18 +12,35 @@ function SettingsProvider({ children }) {
   // * add search field later
 
   function toggleShow() {
+    if (localStorage.getItem('showCompleted')) { localStorage.removeItem('showCompleted'); }
+
     if (showComplete) {
       setShowComplete(false);
+      localStorage.setItem('showCompleted', 'false');
     } else {
       setShowComplete(true);
+      localStorage.setItem('showCompleted', 'true');
     }
   }
 
   function changeItemsPerPage(e) {
+    if (localStorage.getItem('pageNumber')) { localStorage.removeItem('pageNumber'); }
+    localStorage.setItem('itemsPerPage', e.target.value);
+
     const itemsPerPage = Number(e.target.value);
-    console.log(e.target.value);
     setPageNumber(itemsPerPage);
   }
+
+  useEffect(() => {
+    if (localStorage.getItem('itemsPerPage')) {
+      const itemsPerPage = Number(localStorage.getItem('itemsPerPage'));
+      setPageNumber(itemsPerPage);
+    }
+    if (localStorage.getItem('showCompleted')) {
+      const showCompleted = Boolean(localStorage.getItem('showCompleted'));
+      setShowComplete(showCompleted);
+    }
+  }, []);
 
   return (
     <SettingsContext.Provider value={{

--- a/src/hooks/form.js
+++ b/src/hooks/form.js
@@ -9,7 +9,6 @@ const useForm = (callback) => {
   };
 
   const handleChange = (event) => {
-    console.log(event);
     event.persist();
     // eslint-disable-next-line no-shadow
     setValues((values) => ({ ...values, [event.target.name]: event.target.value }));

--- a/src/hooks/form.js
+++ b/src/hooks/form.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-shadow */
 import { useState } from 'react';
 
 const useForm = (callback) => {
@@ -10,7 +11,6 @@ const useForm = (callback) => {
 
   const handleChange = (event) => {
     event.persist();
-    // eslint-disable-next-line no-shadow
     setValues((values) => ({ ...values, [event.target.name]: event.target.value }));
   };
 


### PR DESCRIPTION
# Phase 2 catch up

## Tasks

- [x] Implement pagination with context api
- [x] Hide or show completed items based on context
- [x] Allow the user to set preferences for hide/show and page size
- [x] Save preference to local storage
- [x] Retrieve preferences from local storage

## Notes

There's some hiccups I want to address:
* Serious need to refactor/modularize todo.js...
* Adding items re-renders entire list, sending user back to page 1 
* Show completed doesn't immediately hide finished tasks
* Styling is way off
* Might chuck eslint through a window
* Changing number of items per page doesn't re-render pages in new size
